### PR TITLE
2020 02 24

### DIFF
--- a/Docker/chromedriver/Dockerfile
+++ b/Docker/chromedriver/Dockerfile
@@ -1,0 +1,34 @@
+FROM ruby:2.7.0
+
+ENV LANG C.UTF-8
+ENV TZ=Asia/Tokyo
+
+WORKDIR /app
+
+# nodejs, yarn, postgresql-clientをインストール
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+  && apt-get update -qq \
+  && apt-get install -y nodejs yarn postgresql-client
+
+# 署名を追加(chromeのインストールに必要) -> apt-getでchromeと依存ライブラリをインストール
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add \
+  && echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list \
+  && apt-get update -qq \
+  && apt-get install -y google-chrome-stable libnss3 libgconf-2-4
+
+# chromedriverの最新をインストール
+RUN CHROMEDRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE` \
+  && curl -sS -o /tmp/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
+  && unzip /tmp/chromedriver_linux64.zip \
+  && mv chromedriver /usr/local/bin/
+
+COPY Gemfile .
+COPY Gemfile.lock .
+RUN bundle install
+
+COPY package.json .
+COPY yarn.lock .
+RUN yarn install
+
+# rails serverはdocker-compose.ymlで起動する

--- a/Docker/chromedriver/README.md
+++ b/Docker/chromedriver/README.md
@@ -1,0 +1,42 @@
+# chromedriverをインストールしたRailsのDocker環境
+
+RSpecのFeatureSpecのためにchromedriverが必要だが、docker環境で実行するのは結構しんどかったのでまとめる。
+
+## 環境
+
+```sh
+ruby: 2.7.0
+rails: 6.0.1.2
+postgresql: 12.2
+chromedriver: 80.0.3987.106
+```
+
+## TL;DR
+
+1. chromeのインストール(署名が必要)
+2. 依存ライブラリのインストール
+3. インストールしたchromeのバージョンに合わせたchromedriverをインストール
+4. rails_helper.rbにchromedriverの実行時オプションを追加
+
+この4ステップが必要だった。  
+rails_helperのoptionはこんな感じ  
+
+```ruby
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome, screen_size: [1920, 1080],
+                         options: { args: %w[headless disable-gpu no-sandbox disable-dev-shm-usage] }
+  end
+```
+
+## 何をやってるか
+
+Docker環境は基本的にrootユーザーであり、rootでchromedriverを動かすためにはno-sandboxオプションが必要となる。  
+<https://developers.google.com/web/updates/2017/04/headless-chrome?hl=ja>  
+  
+解決策としては以下の2つがある
+
+- Dockerfileでユーザーとグループを作成し、一般ユーザーで動かす
+- rails_helperにオプションを追加する
+
+Docker環境でのみ必要なオプションをrailsに追加するのは悲しいため、最初はDockerfileでやる方針でやっていた。  
+しかし一般ユーザーに降格すると所々でsudoが必要になりつらい。ローカル環境のrspecでも動作確認をしオプションを追加しても問題なく動くことを確認できているため、塩梅を取って今回はrails_helperを修正する形を取った。  

--- a/Docker/chromedriver/docker-compose.yml
+++ b/Docker/chromedriver/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+volumes:
+  bundle:
+  psql-data:
+services:
+  app:
+    build: .
+    ports:
+      - 3000:3000 # rails server
+      - 3035:3035 # webpack-dev-server
+    volumes:
+      - bundle:/usr/local/bundle:cached
+      - .:/app:delegated
+    environment:
+      POSTGRES_HOST: db # dbコンテナを明示する
+      POSTGRES_PORT: 5432
+    stdin_open: true
+    tty: true
+    command: /bin/sh docker-start.sh
+
+  db:
+    image: postgres:12
+    ports:
+      - 5432:5432
+    volumes:
+    - psql-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres

--- a/Docker/chromedriver/docker-start.sh
+++ b/Docker/chromedriver/docker-start.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+yarn check;
+if ! $? = 0 ; then
+  yarn install;
+fi
+
+bundle install; # Gemfileの更新をチェック
+rm -f /app/tmp/pids/server.pid; # 古いpidファイルを削除
+
+bin/webpack-dev-server & rails server -b 0.0.0.0 -p 3000

--- a/Docker/network.md
+++ b/Docker/network.md
@@ -1,0 +1,15 @@
+# Docker Network
+
+## 役割
+
+- 立ち上げた複数のコンテナ同士の名前解決のために使用するのがdocker network
+- 例えばrailsが動いている `app` コンテナは、 DATABASE_HOSTとして `db` を指定することでDBコンテナに接続することができる
+
+## ネットワークの作成
+
+- `docker network create hogehoge` でhogehogeネットワークを作成できる
+- docker-compose upで勝手にデフォルトのnetworkが作成され、立ち上げたコンテナたちは同じnetworkに所属することになる
+
+## 所感
+
+- 複数のネットワークを管理したいとかがなければ、デフォルトで作成されるnetworkのままで良い気がしている


### PR DESCRIPTION
ryoさんの作っているサービスにdocker環境を入れるお手伝いをしたりしていた。  
https://github.com/ogihara-ryo/sharetil  
DockerでFeatureSpecをやるためのchromedriver, brewだと簡単だけどdocker環境だと結構しんどみが深かった。。Docker環境でRails開発しているプロダクトでE2Eやりたい場合ってここまでしんどいものなのか？皆これを経験してるのか？  
GitHub ActionsやCircleCIは実行時のDockerイメージに既にchromedriverが入っているので簡単らしい。  
うーんchromedriverは別のコンテナ立ち上げたほうがUNIXっぽくていいかなーとも思いつつ、一旦railsのコンテナで動かせるところまで行った。